### PR TITLE
Change the observation client to stream the hypercube.

### DIFF
--- a/transmart-common/pom.xml
+++ b/transmart-common/pom.xml
@@ -23,6 +23,10 @@
 			<artifactId>spring-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-openfeign-core</artifactId>
 		</dependency>
@@ -38,6 +42,10 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
@@ -70,11 +78,6 @@
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.el</artifactId>
 			<version>3.0.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/transmart-common/src/main/java/org/transmartproject/common/client/ObservationClient.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/client/ObservationClient.java
@@ -1,8 +1,26 @@
 package org.transmartproject.common.client;
 
-import org.springframework.cloud.openfeign.FeignClient;
-import org.transmartproject.common.resource.DimensionResource;
-import org.transmartproject.common.resource.ObservationResource;
+import org.springframework.core.io.InputStreamResource;
+import org.transmartproject.common.dto.Query;
 
-@FeignClient(value="observation", url="${transmart-client.transmart-server-url}")
-public interface ObservationClient extends ObservationResource {}
+import javax.validation.Valid;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+/**
+ * Client for observations.
+ * Specifies the endpoint URLs and data types for
+ * observation clients and servers.
+ * The response type is an {@link InputStreamResource}.
+ */
+public interface ObservationClient {
+
+    /**
+     * POST  /v2/observations : query observations.
+     *
+     * @param query the object that contains the constraint.
+     * @param reader the input stream reader
+     */
+    void query(@Valid Query query, Consumer<InputStream> reader);
+
+}

--- a/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
@@ -1,6 +1,8 @@
 package org.transmartproject.common.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,8 @@ import java.util.function.Consumer;
 
 @Component
 public class RestTemplateObservationClient implements ObservationClient {
+
+    private Logger log = LoggerFactory.getLogger(RestTemplateObservationClient.class);
 
     private RestTemplateBuilder restTemplateBuilder;
     private TransmartClientProperties transmartClientProperties;
@@ -32,7 +36,14 @@ public class RestTemplateObservationClient implements ObservationClient {
             String.format("%s/v2/observations", transmartClientProperties.getTransmartServerUrl()),
             HttpMethod.POST,
             request -> objectMapper.writeValue(request.getBody(), query),
-            response -> { reader.accept(response.getBody()); return null; }
+            response -> {
+                try {
+                    reader.accept(response.getBody());
+                } catch(Exception e) {
+                    log.error("Error reading observations", e);
+                }
+                return null;
+            }
         );
     }
 

--- a/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
@@ -1,0 +1,35 @@
+package org.transmartproject.common.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.transmartproject.common.config.TransmartClientProperties;
+import org.transmartproject.common.dto.Query;
+
+import javax.validation.Valid;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+@Component
+public class RestTemplateObservationClient implements ObservationClient {
+
+    private RestTemplateBuilder restTemplateBuilder;
+    private TransmartClientProperties transmartClientProperties;
+
+    RestTemplateObservationClient(RestTemplateBuilder restTemplateBuilder, TransmartClientProperties transmartClientProperties) {
+        this.restTemplateBuilder = restTemplateBuilder;
+        this.transmartClientProperties = transmartClientProperties;
+    }
+
+    @Override
+    public void query(@Valid Query query, Consumer<InputStream> reader) {
+        restTemplateBuilder.build().execute(
+            String.format("%s/v2/observations", transmartClientProperties.getTransmartServerUrl()),
+            HttpMethod.POST,
+            request -> new ObjectMapper().writeValue(request.getBody(), query),
+            response -> { reader.accept(response.getBody()); return null; }
+        );
+    }
+
+}

--- a/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/client/RestTemplateObservationClient.java
@@ -16,10 +16,14 @@ public class RestTemplateObservationClient implements ObservationClient {
 
     private RestTemplateBuilder restTemplateBuilder;
     private TransmartClientProperties transmartClientProperties;
+    private ObjectMapper objectMapper;
 
-    RestTemplateObservationClient(RestTemplateBuilder restTemplateBuilder, TransmartClientProperties transmartClientProperties) {
+    RestTemplateObservationClient(RestTemplateBuilder restTemplateBuilder,
+                                  TransmartClientProperties transmartClientProperties,
+                                  ObjectMapper objectMapper) {
         this.restTemplateBuilder = restTemplateBuilder;
         this.transmartClientProperties = transmartClientProperties;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -27,7 +31,7 @@ public class RestTemplateObservationClient implements ObservationClient {
         restTemplateBuilder.build().execute(
             String.format("%s/v2/observations", transmartClientProperties.getTransmartServerUrl()),
             HttpMethod.POST,
-            request -> new ObjectMapper().writeValue(request.getBody(), query),
+            request -> objectMapper.writeValue(request.getBody(), query),
             response -> { reader.accept(response.getBody()); return null; }
         );
     }

--- a/transmart-common/src/main/java/org/transmartproject/common/config/JacksonConfiguration.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/config/JacksonConfiguration.java
@@ -1,0 +1,22 @@
+package org.transmartproject.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        return mapper;
+    }
+
+}

--- a/transmart-common/src/main/java/org/transmartproject/common/resource/ObservationServer.java
+++ b/transmart-common/src/main/java/org/transmartproject/common/resource/ObservationServer.java
@@ -4,19 +4,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.transmartproject.common.dto.Hypercube;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.transmartproject.common.dto.Query;
-import org.transmartproject.common.constraint.Constraint;
 
 import javax.validation.Valid;
 
 /**
- * Resource for observations.
+ * Server for observations.
  * Specifies the endpoint URLs and data types for
- * observation clients and servers.
+ * observation servers.
+ * The response type is a {@link StreamingResponseBody}.
  */
 @RequestMapping("/v2/observations")
-public interface ObservationResource {
+public interface ObservationServer {
 
     /**
      * POST  /v2/observations : query observations.
@@ -26,6 +26,6 @@ public interface ObservationResource {
      * observations that match the constraint.
      */
     @PostMapping
-    ResponseEntity<Hypercube> query(@Valid @RequestBody Query query);
+    ResponseEntity<StreamingResponseBody> query(@Valid @RequestBody Query query);
 
 }

--- a/transmart-common/src/test/java/org/transmartproject/common/constraint/ConstraintSerialisationTests.java
+++ b/transmart-common/src/test/java/org/transmartproject/common/constraint/ConstraintSerialisationTests.java
@@ -1,9 +1,13 @@
 package org.transmartproject.common.constraint;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.transmartproject.common.config.JacksonConfiguration;
 import org.transmartproject.common.type.DataType;
 import org.transmartproject.common.type.Operator;
 
@@ -11,12 +15,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {JacksonConfiguration.class})
 public class ConstraintSerialisationTests {
+
+    private @Autowired ObjectMapper objectMapper;
 
     @Test
     public void testConstraintSerialisationAndDeserialisation() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-
         List<Constraint> constraints = Arrays.asList(
             new TrueConstraint(),
             ConceptConstraint.builder().conceptCode("concept1").build(),
@@ -31,8 +37,8 @@ public class ConstraintSerialisationTests {
         );
 
         for (Constraint constraint: constraints) {
-            String json = mapper.writeValueAsString(constraint);
-            Constraint object = mapper.readValue(json, Constraint.class);
+            String json = objectMapper.writeValueAsString(constraint);
+            Constraint object = objectMapper.readValue(json, Constraint.class);
             Assert.assertEquals(constraint, object);
         }
     }

--- a/transmart-common/src/test/java/org/transmartproject/common/dto/DimensionElementTests.java
+++ b/transmart-common/src/test/java/org/transmartproject/common/dto/DimensionElementTests.java
@@ -7,6 +7,11 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.transmartproject.common.config.JacksonConfiguration;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -14,7 +19,11 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {JacksonConfiguration.class})
 public class DimensionElementTests {
+
+    private @Autowired ObjectMapper objectMapper;
 
     @Test
     public void testDimensionElementEquals() {
@@ -40,13 +49,6 @@ public class DimensionElementTests {
             .verify();
     }
 
-    private ObjectMapper getMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        return mapper;
-    }
-
     @Test
     public void testVisitDimensionDateSerialisation() throws IOException {
         Map<String, String> encounterIds = new HashMap<>();
@@ -56,7 +58,7 @@ public class DimensionElementTests {
             .startDate(ZonedDateTime.of(2019, 7, 23, 10, 30, 22, 1, ZoneId.of("UTC")))
             .encounterIds(encounterIds)
             .build();
-        String value = getMapper().writeValueAsString(element);
+        String value = objectMapper.writeValueAsString(element);
         Assert.assertEquals("{\"encounterNum\":1," +
             "\"startDate\":\"2019-07-23T10:30:22.000000001Z\"," +
             "\"encounterIds\":{\"VISIT_ID\":\"Visit 1\"}}",

--- a/transmart-common/src/test/resources/logback-test.xml
+++ b/transmart-common/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
 
     <logger name="org.hibernate.validator" level="WARN"/>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="CONSOLE"/>
     </root>
 

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/AsyncConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/AsyncConfiguration.java
@@ -1,39 +1,11 @@
 package org.transmartproject.proxy.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
-import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 @EnableScheduling
-public class AsyncConfiguration implements AsyncConfigurer {
-
-    private final Logger log = LoggerFactory.getLogger(AsyncConfiguration.class);
-
-    @Override
-    @Bean(name = "taskExecutor")
-    public AsyncTaskExecutor getAsyncExecutor() {
-        log.debug("Creating Async Task Executor");
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(50);
-        executor.setQueueCapacity(10000);
-        executor.setThreadNamePrefix("-Executor-");
-        return executor;
-    }
-
-    @Override
-    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-        return new SimpleAsyncUncaughtExceptionHandler();
-    }
-
-}
+public class AsyncConfiguration implements AsyncConfigurer {}

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/AsyncConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/AsyncConfiguration.java
@@ -1,0 +1,39 @@
+package org.transmartproject.proxy.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+@EnableScheduling
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    private final Logger log = LoggerFactory.getLogger(AsyncConfiguration.class);
+
+    @Override
+    @Bean(name = "taskExecutor")
+    public AsyncTaskExecutor getAsyncExecutor() {
+        log.debug("Creating Async Task Executor");
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(10000);
+        executor.setThreadNamePrefix("-Executor-");
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new SimpleAsyncUncaughtExceptionHandler();
+    }
+
+}

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
@@ -23,7 +23,7 @@ import org.transmartproject.proxy.security.CurrentUser;
 @ComponentScan(basePackages = "org.transmartproject.common.client")
 public class FeignConfiguration extends WebMvcConfigurationSupport {
 
-    private @Autowired @Qualifier("taskExecutor") AsyncTaskExecutor asyncTaskExecutor;
+    private @Autowired @Qualifier("taskScheduler") AsyncTaskExecutor asyncTaskExecutor;
 
     @Override
     public void configureAsyncSupport(AsyncSupportConfigurer configurer) {

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
@@ -2,20 +2,33 @@ package org.transmartproject.proxy.config;
 
 import feign.RequestInterceptor;
 import org.apache.http.entity.ContentType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.transmartproject.proxy.security.CurrentUser;
 
 @Configuration
 @EnableFeignClients(basePackages = "org.transmartproject.common.client")
+@ComponentScan(basePackages = "org.transmartproject.common.client")
 public class FeignConfiguration extends WebMvcConfigurationSupport {
+
+    private @Autowired @Qualifier("taskExecutor") AsyncTaskExecutor asyncTaskExecutor;
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setTaskExecutor(asyncTaskExecutor);
+    }
 
     @Bean
     @Override

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/RestTemplateConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/RestTemplateConfiguration.java
@@ -1,0 +1,28 @@
+package org.transmartproject.proxy.config;
+
+import org.apache.http.entity.ContentType;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
+import org.transmartproject.proxy.security.CurrentUser;
+
+@Configuration
+public class RestTemplateConfiguration implements RestTemplateCustomizer {
+
+    @Bean
+    public ClientHttpRequestInterceptor restTemplateRequestInterceptor() {
+        return (request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + CurrentUser.getAccessToken());
+            request.getHeaders().add("Accept", ContentType.APPLICATION_JSON.getMimeType());
+            return execution.execute(request, body);
+        };
+    }
+
+    @Override
+    public void customize(RestTemplate restTemplate) {
+        restTemplate.getInterceptors().add(restTemplateRequestInterceptor());
+    }
+
+}

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
@@ -17,8 +17,6 @@ import org.transmartproject.common.resource.ObservationServer;
 import org.transmartproject.proxy.security.CurrentUser;
 import org.transmartproject.proxy.service.ObservationClientService;
 
-import java.io.IOException;
-
 /**
  * Proxy server for observations.
  */
@@ -44,9 +42,11 @@ public class ObservationProxyServer implements ObservationServer {
         StreamingResponseBody stream = output -> observationClientService.fetchObservations(query,
             input -> {
                 try {
-                    Streams.copy(input, output, false);
-                } catch (IOException e) {
-                    e.printStackTrace();
+                    long byteCount = Streams.copy(input, output, false);
+                    log.debug("{} bytes copied", byteCount);
+                    output.flush();
+                } catch (Exception e) {
+                    log.error("Error reading observations", e);
                     throw new ServiceNotAvailable("Error reading observations", e);
                 }
             });

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
@@ -2,18 +2,22 @@ package org.transmartproject.proxy.server;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.fileupload.util.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
-import org.transmartproject.common.dto.Hypercube;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.transmartproject.common.dto.Query;
-import org.transmartproject.common.constraint.Constraint;
-import org.transmartproject.common.resource.ObservationResource;
+import org.transmartproject.common.exception.ServiceNotAvailable;
+import org.transmartproject.common.resource.ObservationServer;
 import org.transmartproject.proxy.security.CurrentUser;
 import org.transmartproject.proxy.service.ObservationClientService;
+
+import java.io.IOException;
 
 /**
  * Proxy server for observations.
@@ -22,7 +26,7 @@ import org.transmartproject.proxy.service.ObservationClientService;
 @Validated
 @CrossOrigin
 @Api(value="observations", description="Observations")
-public class ObservationProxyServer implements ObservationResource {
+public class ObservationProxyServer implements ObservationServer {
 
     private Logger log = LoggerFactory.getLogger(ObservationProxyServer.class);
 
@@ -35,9 +39,20 @@ public class ObservationProxyServer implements ObservationResource {
 
     @Override
     @ApiOperation(value = "List all observations matching the constraint", produces = "application/json")
-    public ResponseEntity<Hypercube> query(Query query) {
+    public ResponseEntity<StreamingResponseBody> query(Query query) {
         log.info("Query for user {}. Query: {}", CurrentUser.getLogin(), query);
-        return ResponseEntity.ok(observationClientService.fetchObservations(query));
+        StreamingResponseBody stream = output -> observationClientService.fetchObservations(query,
+            input -> {
+                try {
+                    Streams.copy(input, output, false);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    throw new ServiceNotAvailable("Error reading observations", e);
+                }
+            });
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(stream);
     }
 
 }

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/service/ObservationClientService.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/service/ObservationClientService.java
@@ -1,11 +1,11 @@
 package org.transmartproject.proxy.service;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.transmartproject.common.client.ObservationClient;
-import org.transmartproject.common.dto.Hypercube;
 import org.transmartproject.common.dto.Query;
-import org.transmartproject.common.constraint.Constraint;
+
+import java.io.InputStream;
+import java.util.function.Consumer;
 
 @Service
 public class ObservationClientService {
@@ -16,9 +16,8 @@ public class ObservationClientService {
         this.observationClient = observationClient;
     }
 
-    public Hypercube fetchObservations(Query query) {
-        ResponseEntity<Hypercube> response = observationClient.query(query);
-        return ResponseEntityHelper.unwrap(response);
+    public void fetchObservations(Query query, Consumer<InputStream> reader) {
+        observationClient.query(query, reader);
     }
 
 }

--- a/transmart-proxy/src/test/java/org/transmartproject/proxy/server/PatientSetProxyServerTests.java
+++ b/transmart-proxy/src/test/java/org/transmartproject/proxy/server/PatientSetProxyServerTests.java
@@ -38,10 +38,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class PatientSetProxyServerTests {
 
-    @MockBean private PatientSetClient patientSetClient;
+    private @MockBean PatientSetClient patientSetClient;
 
-    @Autowired
-    private MockMvc mvc;
+    private @Autowired MockMvc mvc;
+
+    private @Autowired ObjectMapper objectMapper;
 
     private void setupMockData() throws JsonProcessingException {
         Constraint hypertensionConstraint = AndConstraint.builder()
@@ -56,7 +57,7 @@ public class PatientSetProxyServerTests {
                 .name("Males A")
                 .description("Male patients in study A")
                 .setSize(1000L)
-                .requestConstraints(new ObjectMapper().writeValueAsString(AndConstraint.builder().args(Arrays.asList(
+                .requestConstraints(objectMapper.writeValueAsString(AndConstraint.builder().args(Arrays.asList(
                     StudyNameConstraint.builder().studyId("A").build(),
                     ConceptConstraint.builder().conceptCode("Male").build()
                 )).build()))
@@ -66,7 +67,7 @@ public class PatientSetProxyServerTests {
                 .name("Hypertension")
                 .description("Patients with blood pressure above threshold")
                 .setSize(3000L)
-                .requestConstraints(new ObjectMapper().writeValueAsString(hypertensionConstraint))
+                .requestConstraints(objectMapper.writeValueAsString(hypertensionConstraint))
                 .build()
         );
         // return list of patient sets for /v2/patient_sets
@@ -87,7 +88,7 @@ public class PatientSetProxyServerTests {
                 .id(3L)
                 .name("Test set")
                 .setSize(1234L)
-                .requestConstraints(new ObjectMapper().writeValueAsString(studyConstraint))
+                .requestConstraints(objectMapper.writeValueAsString(studyConstraint))
                 .build()
         );
         doReturn(newPatientSetResponse)
@@ -125,7 +126,7 @@ public class PatientSetProxyServerTests {
     public void givenAvailableClient_whenCreatePatientSet_thenStatus201() throws Exception {
         setupMockData();
         mvc.perform(post("/v2/patient_sets?name=Test set&reuse=true")
-            .content(new ObjectMapper().writeValueAsString(
+            .content(objectMapper.writeValueAsString(
                 StudyNameConstraint.builder().studyId("EHR").build()))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isCreated())


### PR DESCRIPTION
Instead of reading the entire hypercube in memory,
this allows client code to read from an input stream.