### PR TITLE
Set up API Documentation with Swagger 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: linux
 language: java
-jdk: oraclejdk8
+jdk: openjdk11
 
 script:
   -  mvn clean install

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ java -jar transmart-proxy-server/target/transmart-proxy-server-<version>.jar
 
 There should now be an application running at [http://localhost:9050/](http://localhost:9050/).
 
+#### Use
 
+There is a [Swagger documentation](https://swagger.io/solutions/api-documentation/) describing how to use the transmart-proxy API.
+It is exposed at the application URL, by default: [http://localhost:9050/](http://localhost:9050/).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ## Overview
 
+The packages in the TranSMART API library depend on Java 11.
 This repository contains the following packages:
 
 ### transmart-common

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.transmartproject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<equalsverifier.version>3.1.9</equalsverifier.version>
 		<jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<keycloak.version>6.0.1</keycloak.version>
 		<lombok.version>1.18.8</lombok.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>

--- a/transmart-proxy-server/src/main/resources/logback.xml
+++ b/transmart-proxy-server/src/main/resources/logback.xml
@@ -10,6 +10,7 @@
     <logger name="org.springframework.security" level="WARN"/>
     <logger name="org.eclipse.jetty" level="WARN"/>
     <logger name="com.netflix.config" level="ERROR"/>
+    <logger name="springfox.documentation.spring.web" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/transmart-proxy/pom.xml
+++ b/transmart-proxy/pom.xml
@@ -65,6 +65,16 @@
 			<version>${equalsverifier.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.transmartproject.proxy.security.CurrentUser;
@@ -34,6 +35,15 @@ public class FeignConfiguration extends WebMvcConfigurationSupport {
             requestTemplate.header("Authorization", "Bearer " + CurrentUser.getAccessToken());
             requestTemplate.header("Accept", ContentType.APPLICATION_JSON.getMimeType());
         };
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("swagger-ui.html")
+            .addResourceLocations("classpath:/META-INF/resources/");
+
+        registry.addResourceHandler("/webjars/**")
+            .addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
 
 }

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/FeignConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.transmartproject.proxy.security.CurrentUser;
@@ -44,6 +45,11 @@ public class FeignConfiguration extends WebMvcConfigurationSupport {
 
         registry.addResourceHandler("/webjars/**")
             .addResourceLocations("classpath:/META-INF/resources/webjars/");
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/", "/swagger-ui.html");
     }
 
 }

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SecurityConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SecurityConfiguration.java
@@ -51,7 +51,8 @@ class SecurityConfiguration extends KeycloakWebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .antMatchers("/error").permitAll()
-                .antMatchers("/css/**", "/images/**", "/scripts/**", "/swagger.yaml").permitAll()
+                .antMatchers("/swagger-ui.html/**", "/configuration/**", "/swagger-resources/**",
+                    "/v2/api-docs", "/webjars/springfox-swagger-ui/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .csrf().disable();

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
@@ -4,34 +4,59 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
 public class SwaggerConfiguration {
+
+    private static final String VERSION = "v0.0.1";
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
             .select()
-            .apis(RequestHandlerSelectors.any())
+            .apis((RequestHandlerSelectors.basePackage("org.transmartproject.proxy.server")))
             .paths(PathSelectors.any())
             .build()
-            .apiInfo(apiInfo());
+            .apiInfo(apiInfo())
+            .securitySchemes(Arrays.asList(apiKey()))
+            .securityContexts(Arrays.asList(securityContext()));
     }
 
     private ApiInfo apiInfo() {
         return new ApiInfo(
             "TranSMART REST API proxy",
             "Spring Boot application that serves as a TranSMART REST API proxy.",
-            "v0.0.1",
+            VERSION,
             null,
             new Contact("The Hyve", "https://github.com/thehyve/transmart-lib", "office@thehyve.nl"),
-            "MIT", "https://opensource.org/licenses/MIT", Collections.emptyList());
+            "MIT License", "https://opensource.org/licenses/MIT", Collections.emptyList());
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+            .securityReferences(defaultAuth())
+            .forPaths(PathSelectors.any())
+            .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("Bearer", authorizationScopes));
+    }
+
+    private static ApiKey apiKey() {
+        return new ApiKey("Bearer", "Authorization", "header");
     }
 }

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
@@ -18,8 +18,6 @@ import java.util.List;
 @EnableSwagger2
 public class SwaggerConfiguration {
 
-    private static final String VERSION = "v0.0.1";
-
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
@@ -36,7 +34,7 @@ public class SwaggerConfiguration {
         return new ApiInfo(
             "TranSMART REST API proxy",
             "Spring Boot application that serves as a TranSMART REST API proxy.",
-            VERSION,
+            getClass().getPackage().getImplementationVersion(),
             null,
             new Contact("The Hyve", "https://github.com/thehyve/transmart-lib", "office@thehyve.nl"),
             "MIT License", "https://opensource.org/licenses/MIT", Collections.emptyList());

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/config/SwaggerConfiguration.java
@@ -1,0 +1,37 @@
+package org.transmartproject.proxy.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+            .select()
+            .apis(RequestHandlerSelectors.any())
+            .paths(PathSelectors.any())
+            .build()
+            .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfo(
+            "TranSMART REST API proxy",
+            "Spring Boot application that serves as a TranSMART REST API proxy.",
+            "v0.0.1",
+            null,
+            new Contact("The Hyve", "https://github.com/thehyve/transmart-lib", "office@thehyve.nl"),
+            "MIT", "https://opensource.org/licenses/MIT", Collections.emptyList());
+    }
+}

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/AggregateProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/AggregateProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import java.util.Map;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="aggregates", description="Aggregates based on observations")
 public class AggregateProxyServer implements AggregateResource {
 
     private Logger log = LoggerFactory.getLogger(AggregateProxyServer.class);
@@ -34,36 +37,42 @@ public class AggregateProxyServer implements AggregateResource {
     }
 
     @Override
+    @ApiOperation(value = "Observation and patient counts", produces = "application/json")
     public ResponseEntity<Counts> counts(ConstraintParameter constraint) {
         log.info("Get counts for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchCounts(constraint));
     }
 
     @Override
+    @ApiOperation(value = "Observation and patient counts per concept", produces = "application/json")
     public ResponseEntity<Map<String, Counts>> countsPerConcept(ConstraintParameter constraint) {
         log.info("Get counts per concept for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchCountsPerConcept(constraint));
     }
 
     @Override
+    @ApiOperation(value = "Observation and patient counts per study", produces = "application/json")
     public ResponseEntity<Map<String, Counts>> countsPerStudy(ConstraintParameter constraint) {
         log.info("Get counts per study for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchCountsPerStudy(constraint));
     }
 
     @Override
+    @ApiOperation(value = "Observation and patient counts per study and concept", produces = "application/json")
     public ResponseEntity<Map<String, Map<String, Counts>>> countsPerStudyAndConcept(ConstraintParameter constraint) {
         log.info("Get counts per study and concept for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchCountsPerStudyAndConcept(constraint));
     }
 
     @Override
+    @ApiOperation(value = "Calculate numerical values aggregates", produces = "application/json")
     public ResponseEntity<Map<String, NumericalValueAggregates>> numericalValueAggregatesPerConcept(ConstraintParameter constraint) {
         log.info("Get numerical value aggregates for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchNumericalAggregatesPerConcept(constraint));
     }
 
     @Override
+    @ApiOperation(value = "Calculate categorical values aggregates", produces = "application/json")
     public ResponseEntity<Map<String, CategoricalValueAggregates>> categoricalValueAggregatesPerConcept(ConstraintParameter constraint) {
         log.info("Get categorical value aggregates for user {}. Constraint: {}", CurrentUser.getLogin(), constraint);
         return ResponseEntity.ok(aggregateClientService.fetchCategoricalAggregatesPerConcept(constraint));

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/DimensionProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/DimensionProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import org.transmartproject.proxy.service.DimensionClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="dimensions", description="Dimensions")
 public class DimensionProxyServer implements DimensionResource {
 
     private Logger log = LoggerFactory.getLogger(DimensionProxyServer.class);
@@ -30,12 +33,14 @@ public class DimensionProxyServer implements DimensionResource {
     }
 
     @Override
+    @ApiOperation(value = "List all dimensions", produces = "application/json")
     public ResponseEntity<DimensionList> listDimensions() {
         log.info("List all dimension for user {}", CurrentUser.getLogin());
         return ResponseEntity.ok(this.dimensionClientService.fetchDimensions());
     }
 
     @Override
+    @ApiOperation(value = "Get dimension by name", produces = "application/json")
     public ResponseEntity<Dimension> getDimension(String name) {
         log.info("Get dimension with name '{}' for user {}", name, CurrentUser.getLogin());
         return ResponseEntity.ok(this.dimensionClientService.fetchDimension(name));

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/ObservationProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import org.transmartproject.proxy.service.ObservationClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="observations", description="Observations")
 public class ObservationProxyServer implements ObservationResource {
 
     private Logger log = LoggerFactory.getLogger(ObservationProxyServer.class);
@@ -31,6 +34,7 @@ public class ObservationProxyServer implements ObservationResource {
     }
 
     @Override
+    @ApiOperation(value = "List all observations matching the constraint", produces = "application/json")
     public ResponseEntity<Hypercube> query(Query query) {
         log.info("Query for user {}. Query: {}", CurrentUser.getLogin(), query);
         return ResponseEntity.ok(observationClientService.fetchObservations(query));

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/PatientSetProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/PatientSetProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -23,6 +25,7 @@ import javax.validation.constraints.NotBlank;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="patientSets", description="Patient sets")
 public class PatientSetProxyServer implements PatientSetResource {
 
     private Logger log = LoggerFactory.getLogger(PatientSetProxyServer.class);
@@ -35,18 +38,21 @@ public class PatientSetProxyServer implements PatientSetResource {
     }
 
     @Override
+    @ApiOperation(value = "List all patient sets", produces = "application/json")
     public ResponseEntity<PatientSetList> listPatientSets() {
         log.info("List all patient sets for user {}", CurrentUser.getLogin());
         return ResponseEntity.ok(this.patientSetClientService.fetchPatientSets());
     }
 
     @Override
+    @ApiOperation(value = "Get patient set by id", produces = "application/json")
     public ResponseEntity<PatientSetResult> getPatientSet(Long id) {
         log.info("Get patient set with id {} for user {}", id, CurrentUser.getLogin());
         return ResponseEntity.ok(this.patientSetClientService.fetchPatientSet(id));
     }
 
     @Override
+    @ApiOperation(value = "Create patient set", produces = "application/json")
     public ResponseEntity<PatientSetResult> createPatientSet(
         @NotBlank String name, Boolean reuse, @Valid Constraint constraint) {
         log.info("Create patient set with name {} for user {}. Reuse: {}. Constraint: {}",

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/RelationProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/RelationProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import org.transmartproject.proxy.service.RelationClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="relations", description="Relations")
 public class RelationProxyServer implements RelationResource {
 
     private Logger log = LoggerFactory.getLogger(RelationProxyServer.class);
@@ -33,6 +36,7 @@ public class RelationProxyServer implements RelationResource {
     }
 
     @Override
+    @ApiOperation(value = "List all relations", produces = "application/json")
     public ResponseEntity<RelationList> listRelations() {
         log.info("List all relations for user {}", CurrentUser.getLogin());
         return ResponseEntity.ok(this.relationClientService.fetchRelations());

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/RelationTypeProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/RelationTypeProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,7 @@ import org.transmartproject.proxy.service.RelationTypeClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="relationTypes", description="Relation types")
 public class RelationTypeProxyServer implements RelationTypeResource {
 
     private Logger log = LoggerFactory.getLogger(RelationTypeProxyServer.class);
@@ -29,6 +32,7 @@ public class RelationTypeProxyServer implements RelationTypeResource {
     }
 
     @Override
+    @ApiOperation(value = "List all relation types", produces = "application/json")
     public ResponseEntity<RelationTypeList> listRelationTypes() {
         log.info("List all relation types for user {}", CurrentUser.getLogin());
         return ResponseEntity.ok(this.relationTypeClientService.fetchRelationTypes());

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/StudyProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/StudyProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import org.transmartproject.proxy.service.StudyClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="studies", description="Studies")
 public class StudyProxyServer implements StudyResource {
 
     private Logger log = LoggerFactory.getLogger(StudyProxyServer.class);
@@ -30,12 +33,14 @@ public class StudyProxyServer implements StudyResource {
     }
 
     @Override
+    @ApiOperation(value = "List all studies", produces = "application/json")
     public ResponseEntity<StudyList> listStudies() {
         log.info("List all studies for user {}", CurrentUser.getLogin());
         return ResponseEntity.ok(this.studyClientService.fetchStudies());
     }
 
     @Override
+    @ApiOperation(value = "Get study by id", produces = "application/json")
     public ResponseEntity<Study> getStudy(Long id) {
         log.info("Get study with id {} for user {}", id, CurrentUser.getLogin());
         return ResponseEntity.ok(this.studyClientService.fetchStudy(id));

--- a/transmart-proxy/src/main/java/org/transmartproject/proxy/server/TreeProxyServer.java
+++ b/transmart-proxy/src/main/java/org/transmartproject/proxy/server/TreeProxyServer.java
@@ -1,5 +1,7 @@
 package org.transmartproject.proxy.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import org.transmartproject.proxy.service.TreeClientService;
 @RestController
 @Validated
 @CrossOrigin
+@Api(value="tree", description="Ontology tree nodes")
 public class TreeProxyServer implements TreeResource {
 
     private Logger log = LoggerFactory.getLogger(TreeProxyServer.class);
@@ -34,6 +37,7 @@ public class TreeProxyServer implements TreeResource {
 
 
     @Override
+    @ApiOperation(value = "Fetch ontology", produces = "application/json")
     public ResponseEntity<Forest> getForest(
         String root, Integer depth, Boolean constraints, Boolean counts, Boolean tags) {
         log.info("Fetch ontology for user {}", CurrentUser.getLogin());


### PR DESCRIPTION
Adds a basic description of the API endpoints using annotations added to `transmart-proxy`. 
To use the API with Swagger, access token based authorization is configured - after authorizing `Authorization: <Bearer access-token>` header will be applied to the request.

Related ticket: [TMT-961](https://jira.thehyve.nl/browse/TMT-961)
Possible extension: add annotations with description to transmart-common (@\Data classes) to describe the models in details. 
